### PR TITLE
change URL of chromedriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Chrome and [ChromeDriver][chromedriver],
 [go]: http://golang.org/
 [server]: http://seleniumhq.org/download/
 [geckodriver]: https://github.com/mozilla/geckodriver
-[chromedriver]: https://sites.google.com/a/chromium.org/chromedriver/
+[chromedriver]: https://sites.google.com/chromium.org/driver
 [minusnine]: http://github.com/minusnine
 
 ## Installing


### PR DESCRIPTION
Clone of https://github.com/tebeka/selenium/pull/307

The original page says thay have migrated to a new ChromeDriver site