### PR TITLE
Remove GenerateCDProtoContext to avoid unnecessary tight coupling

### DIFF
--- a/internal/seleniumtest/seleniumtest.go
+++ b/internal/seleniumtest/seleniumtest.go
@@ -23,7 +23,6 @@ import (
 
 	socks5 "github.com/armon/go-socks5"
 	"github.com/blang/semver"
-	"github.com/chromedp/cdproto/browser"
 	"github.com/go-auxiliaries/selenium"
 	"github.com/go-auxiliaries/selenium/chrome"
 	"github.com/go-auxiliaries/selenium/firefox"
@@ -1804,35 +1803,8 @@ func testExecuteChromeDPCommand(t *testing.T, c Config) {
 	t.Log(product)
 }
 
-func testGenerateCDProtoContext(t *testing.T, c Config) {
-	caps := newTestCapabilities(t, c)
-
-	wd, err := NewRemote(t, caps, c.Addr)
-	if err != nil {
-		t.Fatalf("newRemote(_, _) returned error: %v", err)
-	}
-	defer func() {
-		_ = wd.Quit()
-	}()
-
-	version := browser.GetVersion()
-
-	_, product, _, _, _, err := version.Do(wd.GenerateCDProtoContext(context.Background()))
-
-	if err != nil {
-		t.Fatalf("cdproto execute error : %s", err.Error())
-	}
-
-	if strings.Index(product, "Chrome") > 0 {
-		t.Log(product)
-	} else {
-		t.Fatalf("invalid chrome version %s", product)
-	}
-}
-
 func RunChromeTests(t *testing.T, c Config) {
 	// Chrome-specific tests.
 	t.Run("Extension", runTest(testChromeExtension, c))
 	t.Run("ExecuteChromeDPCommand", runTest(testExecuteChromeDPCommand, c))
-	t.Run("GenerateCDProtoContext", runTest(testGenerateCDProtoContext, c))
 }

--- a/selenium.go
+++ b/selenium.go
@@ -1,7 +1,6 @@
 package selenium
 
 import (
-	"context"
 	"time"
 
 	"github.com/go-auxiliaries/selenium/chrome"
@@ -446,10 +445,6 @@ type WebDriver interface {
 	// ExecuteChromeDPCommand executes a Chrome DevTools Protocol command.
 	// See https://chromedevtools.github.io/devtools-protocol/ for available commands.
 	ExecuteChromeDPCommand(cmd string, params map[string]interface{}) (interface{}, error)
-	// GenerateCDProtoContext generates context with an executor
-	// which can execute a Chrome DevTools Protocol command through cdproto.
-	// See https://github.com/chromedp/cdproto for usage information.
-	GenerateCDProtoContext(ctx context.Context) context.Context
 	// ExecuteScript executes a script.
 	ExecuteScript(script string, args []interface{}) (interface{}, error)
 	// ExecuteScriptAsync asynchronously executes a script.


### PR DESCRIPTION
After #10 was merged it was decided to drop `GenerateCDProtoContext` to avoid tight coupling. 
Instead it is recomended to implement `GenerateCDProtoContext` analogue apart using `ExecuteChromeDPCommand`
