### PR TITLE
Reduce the error string to the human readable content

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -125,7 +125,7 @@ type Error struct {
 
 // Error implements the error interface.
 func (e *Error) Error() string {
-	return fmt.Sprintf("%s: %s", e.Err, e.Message)
+	return e.Message
 }
 
 // execute performs an HTTP request and inspects the returned data for an error


### PR DESCRIPTION
the problem of concatenating Err and Message is that second includes the first and the result is a little bit weird and does not give more info than only the Message. See one example of such error structure:

<- 404 Not Found [[application/json;charset=utf-8]] {
    'value': {
        'error': 'no such element',
        'message': 'no such element: Unable to locate element: {"method":"css selector","selector":"#IDToken1"}\n  (Session info: headless chrome=102.0.5005.182)',
        'stacktrace': ''
    }
}